### PR TITLE
Add lsp and code formatting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3 - 2024-05-09
+
+* Add `lsp-aiken` for aiken language server support.
+* Add `aiken-fmt` code formatting using utilizing `aiken fmt`
+
 ## 1.0.2 - 2023-09-20
 
 * Fix `auto-mode-alist` entry of `.ak` files.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ commands for the Aiken smart contract language.
 ## Features
 
 - [x] Syntax highlighting
-- [ ] `aiken fmt` command and on-save
+- [x] `aiken fmt` command 
 - [ ] Indentation
-- [ ] Aiken LSP client
+- [x] Aiken LSP client
 
 ## Installation
 
@@ -27,7 +27,14 @@ Add this to your `packages.el`:
 Add this to your `config.el`:
 
 ``` elisp
-(use-package! aiken-mode)
+(use-package! aiken-mode
+  :config
+  (use-package! lsp
+    :hook
+    (aiken-mode . lsp))
+  :bind
+  ("C-c C-b" . aiken-format-buffer))
+  ("C-c C-r" . aiken-format-region))
 ```
 
 and run `doom sync`.
@@ -44,6 +51,13 @@ For faster feedback time during development:
 ```elisp
 (use-package aiken-mode
   :load-path "~/path/to/aiken-mode")
+  :config
+  (use-package lsp
+    :hook
+    (aiken-mode . lsp))
+  :bind
+  ("C-c C-b" . aiken-format-buffer))
+  ("C-c C-r" . aiken-format-region))
 ```
 
 ### vanilla

--- a/aiken-mode.el
+++ b/aiken-mode.el
@@ -1,12 +1,12 @@
-;;; aiken-mode.el --- Major mode for Aiken -*- lexical-binding: t -*-
+
 
 ;; Copyright © 2023 Sebastian Nagel <sebastian.nagel@ncoding.at>
 
 ;; Author: Sebastian Nagel <sebastian.nagel@ncoding.at>
 ;; URL: https://github.com/aiken-lang/aiken-mode
 ;; Keywords: languages aiken
-;; Version: 1.0.2
-;; Package-Requires: ((emacs "26.1"))
+;; Version: 1.0.3
+;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: MPL-2.0
 
 ;; This file is NOT part of GNU Emacs.
@@ -17,7 +17,13 @@
 
 ;;; Commentary:
 
-;; Provides syntax highlighting for the Aiken smart contract language.
+;; Provides Aiken smart contract language with:
+;;    - syntax highlighting
+;;    - lsp client for interacting with aiken language server using  Language Server Protocol
+;;    - aiken code formatting
+;;
+;; Note:
+;; The lsp and aiken code formatter assumes `aiken` binary is in the $PATH
 
 ;;; Code:
 
@@ -116,5 +122,91 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ak\\'" . aiken-mode))
 
+
+(require 'lsp-mode)
+;;
+;; aiken-lsp starts here
+;;
+;; ---------------------------------------------------------------------
+;; Configuration
+
+(defgroup aiken-lsp nil
+  "Customization group for ‘aiken-lsp’."
+  :group 'lsp-mode)
+
+;;
+;; helper functions
+;;
+;; we assume the `aiken' binary is in the $PATH
+(defcustom aiken-lsp-server-path
+  "aiken"
+  "The language server executable.
+Can be something on the $PATH (e.g. `aiken') or a path to an executable itself."
+  :group 'aiken-lsp
+  :type 'string)
+
+;; As of aiken v1.0.26, no args are required. However this might change in future version of aiken
+(defcustom aiken-lsp-server-args
+  `()
+  "The arguments for starting the language server."
+
+  :group 'aiken-lsp
+  :type '(repeat (string :tag "Argument")))
+
+;; As of aiken v1.0.26, no wrapper is required.
+(defcustom aiken-lsp-server-wrapper-function
+  #'identity
+  "Use this wrapp the lsp server process."
+  :group 'aiken-lsp
+  :type '(choice
+          (function-item :tag "None" :value identity)
+          (function :tag "Custom function")))
+
+(defun aiken-lsp--server-command ()
+  "Command and arguments for launching the inferior language server process.
+These are assembled from the customizable variables `aiken-lsp-server-path'
+and `aiken-lsp-server-args' and `aiken-lsp-server-wrapper-function'."
+  (funcall aiken-lsp-server-wrapper-function (append (list aiken-lsp-server-path "lsp") aiken-lsp-server-args) ))
+
+(add-to-list 'lsp-language-id-configuration '(aike-mode . "Aiken"))
+;;
+;; Register the client itself
+;;
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection (lambda () (aiken-lsp--server-command)))
+  ;; should run under aiken-mode
+  :major-modes '(aiken-mode)
+  :server-id 'aiken-lsp
+  :activation-fn (lsp-activate-on "aiken")
+  ;; :initialized-fn (lambda (workspace) (with-lsp-workspace workspace (lsp--set-configuration (lsp-configuration-section "aiken"))))
+  :synchronize-sections '("aiken")
+  :language-id "aiken"))
+
+(add-to-list 'lsp-language-id-configuration '(aiken-mode . "aiken"))
+
+;; aiken-lsp ends here
+;; ---------------------------------------------------------------------
+;; aiken-format starts here
+;;
+(require 'reformatter)
+
+(defcustom aiken-format-aiken-version "0.10"
+  "The version of Aiken against which code should be formatted."
+  :group 'aiken-format
+  :type 'string)
+
+(defcustom aiken-format-command "aiken"
+  "The name of the `aiken-format' command."
+  :group 'aiken-format
+  :type 'string)
+
+(reformatter-define aiken-format
+  :program "aiken"
+  :args (list "fmt"  "--stdin")
+  :group 'aiken-format
+  :lighter " AikenFmt")
+
+;;
 (provide 'aiken-mode)
 ;;; aiken-mode.el ends here


### PR DESCRIPTION
Included two new capabilities:
  - lsp-aiken for aiken language support
  - aiken code formatting. 
 Both capabilities require `aiken` to be in the $PATH

### To verify
Follow the instructions in the README.md `Installation` section.  Open an `aiken` file. You should be greeted with the lsp::aiken-lsp message in the minibuffer.
Next, you may proceed to test the `code formatting` of the entire file or a selected region
